### PR TITLE
Adjust btn-group text color

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -116,8 +116,15 @@ a {
     text-decoration: none; /* No underline by default */
 }
 
+
 a:hover {
     text-decoration: underline; /* Underline on hover */
+}
+
+/* Use the secondary button background as the text color inside .btn-group */
+.btn-group .btn,
+.btn-group a {
+    color: var(--bs-btn-bg, #6c757d);
 }
 
 .btn-group .btn:hover,


### PR DESCRIPTION
## Summary
- tweak css for btn-group so text color matches the secondary button background

## Testing
- `composer test` *(fails: Script phpcs -p -s handling the test event returned with error code 1)*

------
https://chatgpt.com/codex/tasks/task_e_684003f8b54483299934f96e00bb1cc1