### PR TITLE
Fix header/footer width to match content

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -513,10 +513,11 @@ strike {
 }
 
 .Liberty .content-wrapper .liberty-content .liberty-content-header {
-	border: 1px solid #e1e8ed;
-	border-radius: 0.35rem 0.35rem 0 0;
-	background-color: #f5f8fa;
-	max-width: 960px;
+        border: 1px solid #e1e8ed;
+        border-radius: 0.35rem 0.35rem 0 0;
+        background-color: #f5f8fa;
+        width: 100%;
+        max-width: none;
 }
 
 /* 광고 관련 문제 해결(header 부분에 있는 광고가 넘어가는 문제) */
@@ -604,10 +605,11 @@ ins.adsbygoogle {
 
 /* Footer */
 .Liberty .content-wrapper .liberty-footer {
-	border: 1px solid #e1e8ed;
-	border-radius: 0 0 0.35rem 0.35rem;
-	background-color: #f5f8fa;
-	padding: 1rem;
+        border: 1px solid #e1e8ed;
+        border-radius: 0 0 0.35rem 0.35rem;
+        background-color: #f5f8fa;
+        width: 100%;
+        padding: 1rem;
 }
 
 .Liberty .content-wrapper .liberty-footer ul {

--- a/css/default_mobile.css
+++ b/css/default_mobile.css
@@ -34,10 +34,15 @@
 		display: none;
 	}
 
-	.Liberty .content-wrapper .liberty-content {
-		margin-right: auto;
-		padding-bottom: 0.5rem;
-	}
+        .Liberty .content-wrapper .liberty-content {
+                margin-right: auto;
+                padding-bottom: 0.5rem;
+        }
+
+        .Liberty .content-wrapper .liberty-content .liberty-content-header,
+        .Liberty .content-wrapper .liberty-footer {
+                width: 100%;
+        }
 
 	.Liberty .content-wrapper .liberty-content .liberty-content-header .liberty-notice {
 		margin: 0.5rem;


### PR DESCRIPTION
## Summary
- make `.liberty-content-header` width flexible like content
- ensure footer spans same width as main content
- apply the same rule for mobile styles

## Testing
- `npm test`
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684039f095148329825e0b6534f471c0